### PR TITLE
Handles error on POST

### DIFF
--- a/backend.rb
+++ b/backend.rb
@@ -60,7 +60,7 @@ class Backend < Sinatra::Base
     if success
       @user.subscribe!
       article = Article.find(params[:article_id])
-      return json data: article.paid_content
+      return json data: article.paid_content, klarna_response: response_data
     else
       status response_code and return json data: {}, klarna_response: response_data
     end

--- a/models/klarna/purchase.rb
+++ b/models/klarna/purchase.rb
@@ -31,7 +31,7 @@ module Klarna
       resource = RestClient::Resource.new(*resource_params)
 
       resource.post(order_params) do |response|
-        success = response.code.to_s =~ /^2/
+        success = response.code < 300
         [success, success ? response.body : JSON.parse(response.body), response.code]
       end
     end

--- a/redirect_to.rb
+++ b/redirect_to.rb
@@ -14,15 +14,14 @@ class RedirectTo < Sinatra::Base
       origin_proof:  params[:origin_proof]
     )
 
-    authorization_response = purchase.authorize!
-    if authorization_response.success?
+    success, response_data, response_code = purchase.order!
+    if success
       @user.subscribe!
 
-      user_token, order_reference = extract_user_token_and_order_reference(authorization_response.data[1...-1])
+      user_token, order_reference = extract_user_token_and_order_reference(response_data[1...-1])
       return json redirect_to: "/thank_you?user_token=#{user_token}&order_reference=#{order_reference}"
     else
-      status 500
-      return json klarna_response: authorization_response.data
+      status response_code and return json data: {}, klarna_response: response_data
     end
   end
 


### PR DESCRIPTION
* Handles error responses from the SDK calls.
* Return the actual error code (instead of always 500 as we had until today) and message from Klarna.
* That way - if the error is 500 (server error) - we can show the error page. Otherwise - handle accordingly (in invoice purchase for example - we will show the purchase with card step).